### PR TITLE
Make it possible to run jobs in parallel

### DIFF
--- a/piargus/job.py
+++ b/piargus/job.py
@@ -87,6 +87,10 @@ class Job:
 
         return Path(logbook).absolute()
 
+    @property
+    def workdir(self):
+        return self.directory / "work" / self.name
+
     def setup(self, check=True):
         """Generate all files required for TauArgus to run."""
         self._setup_directories()
@@ -106,6 +110,7 @@ class Job:
         output_directory = self.directory / 'output'
         input_directory.mkdir(exist_ok=True)
         output_directory.mkdir(exist_ok=True)
+        self.workdir.mkdir(parents=True, exist_ok=True)
 
     def _setup_input_data(self):
         default = self.directory / 'input' / f"{self.input_data.name}.csv"
@@ -148,9 +153,6 @@ class Job:
     def _setup_batch(self):
         with open(self.batch_filepath, 'w') as batch:
             writer = BatchWriter(batch)
-
-            if self.logbook:
-                writer.logbook(self.logbook_filepath)
 
             if isinstance(self.input_data, Table):
                 writer.open_tabledata(str(self.input_data.filepath))

--- a/piargus/tauargus.py
+++ b/piargus/tauargus.py
@@ -20,7 +20,7 @@ class TauArgus:
         elif hasattr(batch_or_job, 'batch_filepath'):
             returncode, logbook = self._run_job(batch_or_job, *args, **kwargs)
         elif hasattr(batch_or_job, '__iter__'):
-            return self._run_parallel(batch_or_job, check)
+            return self._run_parallel(batch_or_job, check, *args, **kwargs)
         else:
             returncode, logbook = self._run_batch(batch_or_job, *args, **kwargs)
 
@@ -47,13 +47,14 @@ class TauArgus:
             logbook = self.DEFAULT_LOGBOOK
         return subprocess_result.returncode, logbook
 
-    def _run_job(self, job, *args, **kwargs):
-        returncode, logbook = self._run_batch(job.batch_filepath, *args, **kwargs)
-        if hasattr(job, 'logbook_filepath'):
-            logbook = job.logbook_filepath
+    def _run_job(self, job, logbook=None):
+        returncode, logbook = self._run_batch(
+            job.batch_filepath,
+            logbook or job.logbook_filepath,
+            job.workdir)
         return returncode, logbook
 
-    def _run_parallel(self, jobs, check=True):
+    def _run_parallel(self, jobs, check=True, timeout=None):
         """Run multiple jobs at the same time (experimental)"""
         jobs = list(jobs)
 
@@ -62,14 +63,13 @@ class TauArgus:
             for job in jobs:
                 batch_file = str(job.batch_filepath.absolute())
                 log_file = str(job.logbook_filepath.absolute())
-                workdir = job.directory / "work" / job.name
-                workdir.mkdir(parents=True, exist_ok=True)
-                process = subprocess.Popen([self.program, batch_file, log_file, workdir])
+                job.workdir.mkdir(parents=True, exist_ok=True)
+                process = subprocess.Popen([self.program, batch_file, log_file, job.workdir])
                 processes.append(process)
 
             results = []
             for process in processes:
-                result = ArgusReport(process.wait(), Path(process.args[2]))
+                result = ArgusReport(process.wait(timeout), Path(process.args[2]))
                 results.append(result)
         finally:
             for process in processes:

--- a/piargus/tauargus.py
+++ b/piargus/tauargus.py
@@ -56,8 +56,6 @@ class TauArgus:
     def _run_parallel(self, jobs, check=True):
         """Run multiple jobs at the same time (experimental)"""
         jobs = list(jobs)
-        for job in jobs:
-            job.setup()
 
         try:
             processes = []


### PR DESCRIPTION
Ad hoc experimentation with 2 jobs shows a speedup by a factor of 1.5x when running two processes in parallel.
Only the running of tau argus itself has been timed.
I didn't expect much of a speedup, because I would expect the process of solving to be multithreaded already.
Perhaps the solvers are single-threaded or unable to parallelize (or not configured to do so).
Another possibility is some blocking io operations.

Perhaps solve these issues before merge:

- [x] Always create a working dir in job.directory even when not running in parallel
- [x] Maybe add a timeout parameter, because tau argus tends to hang on errors