### PR TITLE
Safety rules simplify

### DIFF
--- a/piargus/__init__.py
+++ b/piargus/__init__.py
@@ -9,8 +9,8 @@ from piargus.job import Job
 from piargus.job import JobSetupError
 from piargus.metadata import MetaData
 from piargus.microdata import MicroData
-from piargus.safetyrule import dominance_rule, p_rule, frequency_rule, request_rule, zero_rule, \
-    missing_rule, weight_rule, manual_rule
+from piargus.safetyrule import dominance_rule, percent_rule, frequency_rule, request_rule, zero_rule, \
+    missing_rule, weight_rule, manual_rule, p_rule, nk_rule
 from piargus.table import Table
 from piargus.tabledata import TableData
 from piargus.tauargus import TauArgus

--- a/piargus/batchwriter.py
+++ b/piargus/batchwriter.py
@@ -1,10 +1,10 @@
-from pathlib import Path
-
 from .constants import FREQUENCY_RESPONSE
+from .utils import format_argument
 
 
 class BatchWriter:
-    """Helper to write a batch file for use with TauArgus.
+    """
+    Helper to write a batch file for use with TauArgus.
 
     Usually the heavy work can be done by creating a Job.
     However, this class can still be used for direct low-level control.
@@ -21,7 +21,7 @@ class BatchWriter:
         return command, arg
 
     def logbook(self, log_file):
-        self.write_command('LOGBOOK', _format_arg(log_file))
+        self.write_command('LOGBOOK', format_argument(log_file))
 
     def open_microdata(self, microdata, sep=','):
         if hasattr(microdata, 'to_csv'):
@@ -30,19 +30,19 @@ class BatchWriter:
         else:
             microdata_file = microdata
 
-        return self.write_command("OPENMICRODATA", _format_arg(microdata_file))
+        return self.write_command("OPENMICRODATA", format_argument(microdata_file))
 
     def open_tabledata(self, tabledata):
-        return self.write_command("OPENTABLEDATA", _format_arg(tabledata))
+        return self.write_command("OPENTABLEDATA", format_argument(tabledata))
 
     def open_metadata(self, metadata):
-        return self.write_command("OPENMETADATA", _format_arg(metadata))
+        return self.write_command("OPENMETADATA", format_argument(metadata))
 
     def specify_table(self, explanatory, response=FREQUENCY_RESPONSE, shadow=None, cost=None, labda=None):
-        explanatory_str = "".join([_format_arg(v) for v in explanatory])
-        response_str = _format_arg(response)
-        shadow_str = _format_arg(shadow)
-        cost_str = _format_arg(cost)
+        explanatory_str = "".join([format_argument(v) for v in explanatory])
+        response_str = format_argument(response)
+        shadow_str = format_argument(shadow)
+        cost_str = format_argument(cost)
         options = f'{explanatory_str}|{response_str}|{shadow_str}|{cost_str}'
         if labda:
             options += f"|{labda}"
@@ -60,8 +60,8 @@ class BatchWriter:
     def apriori(self, filename, table, separator=',', ignore_error=False, expand_trivial=True):
         ignore_error = int(ignore_error)
         expand_trivial = int(expand_trivial)
-        filename = _format_arg(filename)
-        separator = _format_arg(separator)
+        filename = format_argument(filename)
+        separator = format_argument(separator)
         arg = f"{filename}, {table}, {separator}, {ignore_error}, {expand_trivial}"
         return self.write_command("APRIORI", arg)
 
@@ -78,27 +78,14 @@ class BatchWriter:
         if hasattr(options, 'items'):
             options = "".join([k + {True: "+", False: "-"}[v] for k, v in options.items()])
 
-        result = f"({table}, {kind}, {options}, {_format_arg(filename)})"
+        result = f"({table}, {kind}, {options}, {format_argument(filename)})"
         return self.write_command('WRITETABLE', result)
 
     def version_info(self, filename):
-        return self.write_command("VERSIONINFO", _format_arg(filename))
+        return self.write_command("VERSIONINFO", format_argument(filename))
 
     def go_interactive(self):
         return self.write_command("GOINTERACTIVE")
 
     def clear(self):
         return self.write_command("CLEAR")
-
-
-def _format_arg(text):
-    if text is None:
-        return ""
-    elif isinstance(text, Path):
-        return f'"{text!s}"'
-    elif isinstance(text, str):
-        return f'"{text!s}"'
-    elif isinstance(text, bool):
-        return str(int(text))
-    else:
-        return str(text)

--- a/piargus/job.py
+++ b/piargus/job.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Tuple, Any, Union
 from .batchwriter import BatchWriter
 from .inputdata import InputData
 from .metadata import MetaData
-from .safetyrule import join_rules_with_holding
+from .utils import join_rules_with_holding
 from .table import Table
 
 

--- a/piargus/job.py
+++ b/piargus/job.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Tuple, Any, Union
 from .batchwriter import BatchWriter
 from .inputdata import InputData
 from .metadata import MetaData
-from .safetyrule import make_safety_rule
+from .safetyrule import join_rules_with_holding
 from .table import Table
 
 
@@ -169,7 +169,7 @@ class Job:
                 writer.specify_table(table.explanatory, table.response, table.shadow, table.cost,
                                      table.labda)
 
-                safety_rules = make_safety_rule(table.safety_rules, table.safety_rules_holding)
+                safety_rules = join_rules_with_holding(table.safety_rules, table.safety_rules_holding)
                 writer.safety_rule(safety_rules)
 
             if isinstance(self.input_data, Table):

--- a/piargus/safetyrule.py
+++ b/piargus/safetyrule.py
@@ -1,44 +1,20 @@
-import functools
-import inspect
-from typing import Sequence
-
-
-class SafetyRule:
-    def __init__(self, code, check_function, maximum=None, dummy=None):
-        self.code = code
-        self.check_function = check_function
-        self.maximum = maximum
-        self.dummy = dummy
-
-    def __repr__(self):
-        return f"<SafetyRule: {self}>"
-
-    def __str__(self):
-        sig = inspect.signature(self.check_function)
-        param_str = ", ".join(sig.parameters)
-        return f"{self.__name__}({param_str})"
-
-    def __call__(self, *args, **kwargs):
-        sig = inspect.signature(self.check_function)
-        ba = sig.bind(*args, **kwargs)
-        ba.apply_defaults()
-
-        values = self.check_function(*ba.args, **ba.kwargs)
-        if values is None:
-            values = tuple(ba.arguments.values())
-            
-        if len(values) == 1:
-            (value,) = values
-            return f"{self.code}({value})"
-        else:
-            return f"{self.code}{values}"
-
-
 def safety_rule(code, maximum=None, dummy=None):
-    def accept_function(check_function):
-        rule = SafetyRule(code, check_function, maximum, dummy)
-        functools.update_wrapper(rule, check_function)
-        return rule
+    """
+    Decorator to add metadata to safety rule.
+
+    A safety rule is a function returning a string.
+    Because of how the batch api works some metadata is useful.
+
+    :param code: Code used by batch file
+    :param maximum: How often the rule can be applied. The rule can be used this many times
+    on the individual level and this many times on the holding level.
+    :param dummy: If the rule can be set on holding level, use dummy to fill individual level slots.
+    """
+    def accept_function(safety_function):
+        safety_function.code = code
+        safety_function.maximum = maximum
+        safety_function.dummy = dummy
+        return safety_function
 
     return accept_function
 
@@ -50,13 +26,17 @@ def dominance_rule(n=3, k=75):
     if not (0 <= k <= 100):
         raise ValueError("k should be a percentage")
 
+    return f"NK{n, k}"
+
 
 @safety_rule("P", maximum=2, dummy="P(0, 0)")
-def p_rule(p, n=1):
+def percent_rule(p=10, n=1):
     if n < 1:
         raise ValueError("n should be positive")
     if not (0 <= p <= 100):
         raise ValueError("p should be a percentage")
+
+    return f"P{p, n}"
 
 
 @safety_rule("FREQ", maximum=1, dummy="FREQ(0, 0)")
@@ -66,6 +46,8 @@ def frequency_rule(n, safety_range):
     if not (0 <= safety_range <= 100):
         raise ValueError("safety_range should be a percentage")
 
+    return f"FREQ{n, safety_range}"
+
 
 @safety_rule("REQ", maximum=1, dummy="REQ(0, 0, 0)")
 def request_rule(percent1, percent2, safety_margin):
@@ -74,20 +56,23 @@ def request_rule(percent1, percent2, safety_margin):
     if not (0 <= percent2 <= 100):
         raise ValueError("percent2 should be a percentage")
 
+    return f"REQ{percent1, percent2, safety_margin}"
+
 
 @safety_rule("ZERO", maximum=1)
 def zero_rule(safety_range):
     pass  # TODO Unclear from manual how to use safety_range and what to check
+    return f"ZERO({safety_range})"
 
 
 @safety_rule("MIS")
 def missing_rule(is_safe=False):
-    return int(is_safe),
+    return f"MIS({int(is_safe)})"
 
 
 @safety_rule("WGT")
 def weight_rule(apply_weights=False):
-    return int(apply_weights),
+    return f"WGT({int(apply_weights)})"
 
 
 @safety_rule("MAN")
@@ -95,10 +80,12 @@ def manual_rule(margin=20):
     if not (0 <= margin <= 100):
         raise ValueError("margin should be a percentage")
 
+    return f"MAN({margin})"
+
 
 RULES = [
     dominance_rule,
-    p_rule,
+    percent_rule,
     frequency_rule,
     request_rule,
     zero_rule,
@@ -107,31 +94,6 @@ RULES = [
     manual_rule,
 ]
 
-
-def join_rules_with_holding(rules_individual, rules_holding) -> Sequence[str]:
-    """
-    Join rules on individual level and holding level.
-
-    Create a safety rules from the rules on an individual level and on holding level.
-    """
-    dummy_rules = []  # Boundary between individual and holding rules
-    for rule in RULES:
-        i_match = [i_rule for i_rule in rules_individual
-                   if i_rule.startswith(rule.code)]
-        h_match = [h_rule for h_rule in rules_holding
-                   if h_rule.startswith(rule.code)]
-
-        if rule.maximum is not None:
-            if len(i_match) > rule.maximum:
-                raise ValueError(f"Rule {rule.code} can only appear {rule.maximum} times.")
-            if len(h_match) > rule.maximum:
-                raise ValueError(f"Rule {rule.code} can only appear {rule.maximum} times.")
-
-            if rule.dummy is not None and len(h_match) > 0:
-                n_dummies = rule.maximum - len(i_match)
-                dummy_rules.extend(n_dummies * [rule.dummy])
-
-    safety_rules = list(rules_individual)
-    safety_rules.extend(dummy_rules)
-    safety_rules.extend(rules_holding)
-    return safety_rules
+# Aliases for consistency with τ-argus-api
+nk_rule = dominance_rule
+p_rule = percent_rule

--- a/piargus/table.py
+++ b/piargus/table.py
@@ -14,18 +14,20 @@ STATUS_CODES = {
 
 
 class Table:
-    def __init__(self,
-                 explanatory,
-                 response=FREQUENCY_RESPONSE,
-                 shadow=None,
-                 cost=None,
-                 labda=None,
-                 name=None,
-                 safety_rules=None,
-                 safety_rules_holding=None,
-                 apriori=None,
-                 suppress_method=None,
-                 suppress_method_args=None):
+    def __init__(
+            self,
+            explanatory,
+            response=FREQUENCY_RESPONSE,
+            shadow=None,
+            cost=None,
+            labda=None,
+            name=None,
+            safety_rules=(),
+            safety_rules_holding=(),
+            apriori=None,
+            suppress_method=None,
+            suppress_method_args=None
+    ):
         """
         A Table instance describes the output of the table.
 
@@ -43,11 +45,11 @@ class Table:
         Default: 1.
         :param safety_rules: A set of safety rules on individual level.
         Options are:
-        - P(p, n) - For p-rule
-        - NK(n, k) - Dominance rule
-        - ZERO(safety_range) - Zero rule
-        - FREQ(minfreq, safety_range) - Frequency rule
-        - REQ(percentage_1, percentage_2, safety_margin) - Request rule
+        - "P(p, n)": p% rule
+        - "NK(n, k)": (n, k)-dominance rule
+        - "ZERO(safety_range)": Zero rule
+        - "FREQ(minfreq, safety_range)": Frequency rule
+        - "REQ(percentage_1, percentage_2, safety_margin)": Request rule
         See the Tau-Argus manual for details on those rules.
         :param safety_rules_holding: A set of safety rules which are applied on holding level.
         :param name: Name to use for generated files
@@ -122,9 +124,7 @@ class Table:
 
 
 def _normalize_safety_rules(value):
-    if value is None:
-        value = set()
-    elif isinstance(value, str):
+    if isinstance(value, str):
         value = set(value.split('|'))
     else:
         value = set(value)

--- a/piargus/tabledata.py
+++ b/piargus/tabledata.py
@@ -13,26 +13,27 @@ DEFAULT_STATUS_MARKERS = {
 
 
 class TableData(InputData, Table):
-    def __init__(self,
-                 dataset,
-                 explanatory,
-                 response,
-                 shadow=None,
-                 cost=None,
-                 labda=None,
-                 total_codes='Total',
-                 frequency=None,
-                 top_contributors=None,
-                 lower_protection_level=None,
-                 upper_protection_level=None,
-                 status_indicator=None,
-                 status_markers=None,
-                 safety_rules=None,
-                 safety_rules_holding=None,
-                 apriori=None,
-                 suppress_method=None,
-                 suppress_method_args=None,
-                 **kwargs):
+    def __init__(
+            self,
+            dataset,
+            explanatory,
+            response,
+            shadow=None,
+            cost=None,
+            labda=None,
+            total_codes='Total',
+            frequency=None,
+            top_contributors=None,
+            lower_protection_level=None,
+            upper_protection_level=None,
+            status_indicator=None,
+            status_markers=None,
+            safety_rules=(),
+            apriori=None,
+            suppress_method=None,
+            suppress_method_args=None,
+            **kwargs
+    ):
         """
         A TableData instance contains data which has already been aggregated.
 
@@ -67,7 +68,6 @@ class TableData(InputData, Table):
                        cost=cost,
                        labda=labda,
                        safety_rules=safety_rules,
-                       safety_rules_holding=safety_rules_holding,
                        apriori=apriori,
                        suppress_method=suppress_method,
                        suppress_method_args=suppress_method_args)

--- a/piargus/test/test_rules.py
+++ b/piargus/test/test_rules.py
@@ -21,27 +21,6 @@ class TestSafetyRule(unittest.TestCase):
         with self.assertRaises(ValueError):
             rule.dominance_rule(n=-1, k=110)
 
-    def test_make_safety_rules(self):
-        result = rule.join_rules_with_holding(
-            {rule.dominance_rule(3, 75), rule.frequency_rule(5, 20)},
-            {rule.p_rule(5), rule.frequency_rule(6, 15), rule.request_rule(2, 2, 9)},
-        )
-        expected = [
-            'NK(3, 75)',
-            'FREQ(5, 20)',
-            'P(0, 0)',
-            'P(0, 0)',
-            'REQ(0, 0, 0)',
-            'P(5, 1)',
-            'FREQ(6, 15)',
-            'REQ(2, 2, 9)'
-        ]
-        self.assertCountEqual(expected, result)
-
-    def test_make_safety_rule_maximum(self):
-        with self.assertRaises(ValueError):
-            rule.join_rules_with_holding([rule.p_rule(2), rule.p_rule(3), rule.p_rule(4)], [])
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/piargus/test/test_rules.py
+++ b/piargus/test/test_rules.py
@@ -22,7 +22,7 @@ class TestSafetyRule(unittest.TestCase):
             rule.dominance_rule(n=-1, k=110)
 
     def test_make_safety_rules(self):
-        result = rule.make_safety_rule(
+        result = rule.join_rules_with_holding(
             {rule.dominance_rule(3, 75), rule.frequency_rule(5, 20)},
             {rule.p_rule(5), rule.frequency_rule(6, 15), rule.request_rule(2, 2, 9)},
         )
@@ -40,7 +40,7 @@ class TestSafetyRule(unittest.TestCase):
 
     def test_make_safety_rule_maximum(self):
         with self.assertRaises(ValueError):
-            rule.make_safety_rule([rule.p_rule(2), rule.p_rule(3), rule.p_rule(4)], [])
+            rule.join_rules_with_holding([rule.p_rule(2), rule.p_rule(3), rule.p_rule(4)], [])
 
 
 if __name__ == '__main__':

--- a/piargus/test/test_utils.py
+++ b/piargus/test/test_utils.py
@@ -1,0 +1,31 @@
+import unittest
+
+import piargus as pa
+from piargus.utils import join_rules_with_holding
+
+
+class TestUtils(unittest.TestCase):
+    def test_join_rules_with_holding(self):
+        result = join_rules_with_holding(
+            {pa.dominance_rule(3, 75), pa.frequency_rule(5, 20)},
+            {pa.p_rule(5), pa.frequency_rule(6, 15), pa.request_rule(2, 2, 9)},
+        )
+        expected = [
+            'NK(3, 75)',
+            'FREQ(5, 20)',
+            'P(0, 0)',
+            'P(0, 0)',
+            'REQ(0, 0, 0)',
+            'P(5, 1)',
+            'FREQ(6, 15)',
+            'REQ(2, 2, 9)'
+        ]
+        self.assertCountEqual(expected, result)
+
+    def test_make_safety_rule_maximum(self):
+        with self.assertRaises(ValueError):
+            join_rules_with_holding([pa.p_rule(2), pa.p_rule(3), pa.p_rule(4)], [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/piargus/utils.py
+++ b/piargus/utils.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+from typing import Sequence
+
+from piargus.safetyrule import RULES
+
+
+def join_rules_with_holding(rules_individual, rules_holding) -> Sequence[str]:
+    """
+    Join rules on individual level and holding level.
+
+    Create a safety rules from the rules on an individual level and on holding level.
+    """
+    dummy_rules = []  # Boundary between individual and holding rules
+    for rule in RULES:
+        i_match = [i_rule for i_rule in rules_individual
+                   if i_rule.startswith(rule.code)]
+        h_match = [h_rule for h_rule in rules_holding
+                   if h_rule.startswith(rule.code)]
+
+        if rule.maximum is not None:
+            if len(i_match) > rule.maximum:
+                raise ValueError(f"Rule {rule.code} can only appear {rule.maximum} times.")
+            if len(h_match) > rule.maximum:
+                raise ValueError(f"Rule {rule.code} can only appear {rule.maximum} times.")
+
+            if rule.dummy is not None and len(h_match) > 0:
+                n_dummies = rule.maximum - len(i_match)
+                dummy_rules.extend(n_dummies * [rule.dummy])
+
+    safety_rules = list(rules_individual)
+    safety_rules.extend(dummy_rules)
+    safety_rules.extend(rules_holding)
+    return safety_rules
+
+
+def format_argument(text):
+    if text is None:
+        return ""
+    elif isinstance(text, Path):
+        return f'"{text!s}"'
+    elif isinstance(text, str):
+        return f'"{text!s}"'
+    elif isinstance(text, bool):
+        return str(int(text))
+    else:
+        return str(text)


### PR DESCRIPTION
Safety rules were overengineered. This simplifies their implementation. No inspection needed.

In addition create aliases for consistency with argus:
- `p_rule is procent_rule`
- `nk_rule is dominance_rule`