### PR TITLE
Make it possible to set total codes on microdata

### DIFF
--- a/examples/microdata_basic.py
+++ b/examples/microdata_basic.py
@@ -6,15 +6,15 @@ def main():
     tau = pa.TauArgus(r'C:\Users\LVWN\Desktop\TauArgus4.2.0b5\TauArgus')
     input_df = pd.read_csv('data/microdata.csv')
     input_data = pa.MicroData(input_df, name='example')
-    tables = [pa.Table(['sbi', 'regio'], 'income',
-                       name='T1',
-                       safety_rules={pa.dominance_rule(3, 70),
-                                     pa.frequency_rule(3, 20),
-                                     pa.zero_rule(20)},
-                       suppress_method=pa.OPTIMAL)]
-    job = pa.Job(input_data, tables, directory='tau', name='microdata_example')
+    output_table = pa.Table(['sbi', 'regio'], 'income',
+                            name='T1',
+                            safety_rules={pa.dominance_rule(3, 70),
+                                          pa.frequency_rule(3, 20),
+                                          pa.zero_rule(20)},
+                            suppress_method=pa.OPTIMAL)
+    job = pa.Job(input_data, [output_table], directory='tau', name='microdata_example')
     report = tau.run(job)
-    table_result = tables[0].load_result()
+    table_result = output_table.load_result()
 
     print(report)
     print(table_result)

--- a/examples/microdata_hierarchy.py
+++ b/examples/microdata_hierarchy.py
@@ -1,0 +1,29 @@
+import pandas as pd
+import piargus as pa
+
+
+def main():
+    tau = pa.TauArgus(r'C:\Users\LVWN\Desktop\TauArgus4.2.0b5\TauArgus')
+    input_df = pd.read_csv('data/microdata.csv')
+    sbi_hierarchy = pa.Hierarchy(["A", "C"])
+    regio_hierarchy = pa.Hierarchy({"Example": ["ExampleDam", "ExampleCity"]})
+    input_data = pa.MicroData(
+        input_df,
+        name='example',
+        hierarchies={'sbi': sbi_hierarchy, "regio": regio_hierarchy},
+        total_codes={"sbi": "Industry", "regio": "Country"},
+    )
+    output_table = pa.Table(['sbi', 'regio'], 'income',
+                            name='T_hier',
+                            safety_rules={pa.dominance_rule(3, 70), pa.zero_rule(20)})
+    job = pa.Job(input_data, [output_table], directory='tau', name='microdata_total_example')
+    report = tau.run(job)
+    table_result = output_table.load_result()
+
+    print(report)
+    print(table_result)
+    table_result.dataframe().to_csv("output/result_hierarchy.csv")
+
+
+if __name__ == '__main__':
+    main()

--- a/piargus/table.py
+++ b/piargus/table.py
@@ -28,13 +28,15 @@ class Table:
         A simple table can be created from MicroData.
 
         Parameters:
-        :param explanatory: List of background variables that explain the response. Will be set as a Dataframe-index.
+        :param explanatory: List of background variables that explain the response.
+        Will be set as a Dataframe-index.
         :param response: The column that needs to be explained.
         :param shadow: The column that is used for the safety rules. Default: response.
         :param cost: The column that contains the cost of suppressing a cell.
         Set to 1 to minimise the number of cells suppressed (although this might suppress totals).
         Default: response.
-        :param labda: If set to a value > 0, a box-cox transformation is applied on the cost variable.
+        :param labda: If set to a value > 0, a box-cox transformation is applied on the cost
+        variable.
         If set to 0, a log transformation is applied on the cost.
         Default: 1.
         :param safety_rules: A set of safety rules on individual level.


### PR DESCRIPTION
Until now it was only possible to supply total codes on tabledata. After this pull request it's also possible to set them on table data.

I noticed that tabledata didn't have a suppression method set by default. For consistency with normal table, this has been set to 'optimal'. Perhaps cleaner to do this in a separate PR, but well ...