### PR TITLE
Tableset recode

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ It's also recommended to read the [TauArgus manual](https://research.cbs.nl/casc
 
 - Generate output tables from microdata or tabledata. It is recommended to generate from microdata.
 - Metadata can be generated automatically, although using an existing rda-file is also possible.
-- It's possible to create hierarchies, codelists, apriori files all from code or from existing files.
-- Error checking of input is done before input is supplied to argus.
+- It's possible to create hierarchies, codelists, apriori files, recode files all from code or from existing files.
+- Basic error checking of input is done before input is supplied to argus.
 
-Feel free to [contribute](https://github.com/lverweijen/piargus) support for other useful TauArgus-features.
+Feel free to [contribute](https://github.com/lverweijen/piargus) for other TauArgus-features.
 [Feedback](https://github.com/lverweijen/piargus/issues) is welcome too.
 
 ## Installing
 
-- Download and install the latest version of [τ-ARGUS](https://research.cbs.nl/casc/tau.htm).
+- Download and install the latest version of [τ-ARGUS](https://github.com/sdcTools/tauargus/releases).
 - Then use [pip](https://pip.pypa.io/en/stable/getting-started/) to install piargus:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ It's also recommended to read the [TauArgus manual](https://research.cbs.nl/casc
 ## Features
 
 - Generate output tables from microdata or tabledata. It is recommended to generate from microdata.
-- Error checking is done to prevent most errors that make argus hang forever.
 - Metadata can be generated automatically, although using an existing rda-file is also possible.
 - It's possible to create hierarchies, codelists, apriori files all from code or from existing files.
+- Error checking of input is done before input is supplied to argus.
 
 Feel free to [contribute](https://github.com/lverweijen/piargus) support for other useful TauArgus-features.
 [Feedback](https://github.com/lverweijen/piargus/issues) is welcome too.

--- a/changes.md
+++ b/changes.md
@@ -1,5 +1,8 @@
-Version 0.2.0
+## Version 0.2.0 ##
 
 - Remove `name` parameter on most object, except Job
 - Job construct now accepts tables as both iterable or dict.
   Tables will now be stored in a TableSet object.
+- Experimental linked protection is possible by using a TableSet.
+  Although it seems to work fine, this feature is not documented in the manual.
+  Therefore, usage cannot be recommended.

--- a/changes.md
+++ b/changes.md
@@ -2,6 +2,9 @@
 
 - Add support for recode table (requires TauArgus version >= 4.2.4).
 - Make `name` parameter on most objects obsolete, except Job.
+- Remove obsolete parameter `safety_rules_holding`.
+  Parameter `safety_rule` is very flexible and can be passed a dict.
+- Improve the methods of `BatchWriter` to accept both strings and objects.
 - Tables can now be passed to Job as both iterable or dict.
   Tables will now be stored in a TableSet object.
 - Experimental linked protection is possible when using a TableSet.

--- a/changes.md
+++ b/changes.md
@@ -1,8 +1,9 @@
 ## Version 0.2.0 ##
 
-- Remove `name` parameter on most object, except Job
-- Job construct now accepts tables as both iterable or dict.
+- Add support for recode table (requires TauArgus version >= 4.2.4).
+- Make `name` parameter on most objects obsolete, except Job.
+- Tables can now be passed to Job as both iterable or dict.
   Tables will now be stored in a TableSet object.
-- Experimental linked protection is possible by using a TableSet.
-  Although it seems to work fine, this feature is not documented in the manual.
-  Therefore, usage cannot be recommended.
+- Experimental linked protection is possible when using a TableSet.
+  Although it seems to produce output, this feature is not documented in the Tau Argus manual.
+  Therefore, usage cannot be recommended (a warning will be shown).

--- a/changes.md
+++ b/changes.md
@@ -1,0 +1,5 @@
+Version 0.2.0
+
+- Remove `name` parameter on most object, except Job
+- Job construct now accepts tables as both iterable or dict.
+  Tables will now be stored in a TableSet object.

--- a/examples/microdata_apriori.py
+++ b/examples/microdata_apriori.py
@@ -5,7 +5,7 @@ import piargus as pa
 def main():
     tau = pa.TauArgus(r'C:\Users\LVWN\Desktop\TauArgus4.2.0b5\TauArgus')
     input_df = pd.read_csv('data/microdata.csv')
-    input_data = pa.MicroData(input_df, name='example')
+    input_data = pa.MicroData(input_df)
 
     apriori = pa.Apriori(expand_trivial=True)
     apriori.change_status(['A', 'ExampleDam'], pa.SAFE)
@@ -13,7 +13,7 @@ def main():
     apriori.change_cost(['C', 'ExampleDam'], 10)
     apriori.change_protection_level(['C', 'ExampleCity'], 5)
 
-    tables = [pa.Table(['sbi', 'regio'], 'income', name='T3',
+    tables = [pa.Table(['sbi', 'regio'], 'income',
                        safety_rule={'NK(3,70)', 'FREQ(3,20)', 'ZERO(20)'},
                        apriori=apriori,
                        suppress_method='OPT')]

--- a/examples/microdata_apriori.py
+++ b/examples/microdata_apriori.py
@@ -18,7 +18,7 @@ def main():
                        apriori=apriori,
                        suppress_method='OPT')]
 
-    job = pa.Job(input_data, tables, directory='tau', name='apriori_example')
+    job = pa.Job(input_data, tables, directory='tau', name='apriori-example')
     report = tau.run(job)
     table_result = tables[0].load_result()
 

--- a/examples/microdata_apriori.py
+++ b/examples/microdata_apriori.py
@@ -3,7 +3,7 @@ import piargus as pa
 
 
 def main():
-    tau = pa.TauArgus(r'C:\Users\LVWN\Desktop\TauArgus4.2.0b5\TauArgus')
+    tau = pa.TauArgus(r'C:\Users\LVWN\Desktop\TauArgus4.2.4b2\TauArgus')
     input_df = pd.read_csv('data/microdata.csv')
     input_data = pa.MicroData(input_df)
 

--- a/examples/microdata_basic.py
+++ b/examples/microdata_basic.py
@@ -4,13 +4,11 @@ import piargus as pa
 
 def main():
     tau = pa.TauArgus(r'C:\Users\LVWN\Desktop\TauArgus4.2.0b5\TauArgus')
-    input_df = pd.read_csv('data/microdata.csv')
-    input_data = pa.MicroData(input_df, name='example')
+    input_data = pa.MicroData(pd.read_csv('data/microdata.csv'))
     output_table = pa.Table(['sbi', 'regio'], 'income',
-                            name='T1',
                             safety_rule=pa.percent_rule(p=10),
                             suppress_method=pa.OPTIMAL)
-    job = pa.Job(input_data, [output_table], directory='tau', name='microdata_example')
+    job = pa.Job(input_data, [output_table], directory='tau', name='basic-example')
     report = tau.run(job)
     table_result = output_table.load_result()
 

--- a/examples/microdata_hierarchy.py
+++ b/examples/microdata_hierarchy.py
@@ -9,14 +9,12 @@ def main():
     regio_hierarchy = pa.Hierarchy({"Example": ["ExampleDam", "ExampleCity"]})
     input_data = pa.MicroData(
         input_df,
-        name='example',
         hierarchies={'sbi': sbi_hierarchy, "regio": regio_hierarchy},
         total_codes={"sbi": "Industry", "regio": "Country"},
     )
     output_table = pa.Table(['sbi', 'regio'], 'income',
-                            name='T_hier',
                             safety_rule={pa.dominance_rule(3, 70), pa.zero_rule(20)})
-    job = pa.Job(input_data, [output_table], directory='tau', name='microdata_total_example')
+    job = pa.Job(input_data, [output_table], directory='tau', name='hierarchy-example')
     report = tau.run(job)
     table_result = output_table.load_result()
 

--- a/examples/microdata_holding.py
+++ b/examples/microdata_holding.py
@@ -5,9 +5,8 @@ import piargus as pa
 def main():
     tau = pa.TauArgus(r'C:\Users\LVWN\Desktop\TauArgus4.2.0b5\TauArgus')
     input_df = pd.read_csv('data/microdata.csv')
-    input_data = pa.MicroData(input_df, name='example', holding='holding')
+    input_data = pa.MicroData(input_df, holding='holding')
     tables = [pa.Table(['sbi', 'regio'], 'income',
-                       name='T4',
                        safety_rule={
                            "individual": {pa.dominance_rule(2, 70), pa.missing_rule(True)},
                            "holding": {pa.dominance_rule(1, 90), pa.frequency_rule(1, 20)},

--- a/examples/microdata_recode.py
+++ b/examples/microdata_recode.py
@@ -1,0 +1,28 @@
+import pandas as pd
+import piargus as pa
+
+
+def main():
+    tau = pa.TauArgus(r'C:\Users\LVWN\Desktop\TauArgus4.2.4b2\TauArgus')
+    input_df = pd.read_csv('data/microdata.csv')
+    sbi_hierarchy = pa.Hierarchy(["A", "C"])
+    regio_hierarchy = pa.Hierarchy({"Example": ["ExampleDam", "ExampleCity"]})
+    input_data = pa.MicroData(
+        input_df,
+        hierarchies={'sbi': sbi_hierarchy, "regio": regio_hierarchy},
+        total_codes={"sbi": "Industry", "regio": "Country"},
+    )
+    output_table = pa.Table(['sbi', 'regio'], 'income',
+                            safety_rule={pa.p_rule(3)},
+                            recodes={"regio": ["Example"], "sbi": 1})
+    job = pa.Job(input_data, [output_table], directory='tau', name='recode-example')
+    report = tau.run(job)
+    table_result = output_table.load_result()
+
+    print(report)
+    print(table_result)
+    table_result.dataframe().to_csv("output/result_recode.csv")
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/microdata_response.py
+++ b/examples/microdata_response.py
@@ -5,11 +5,10 @@ import piargus as pa
 def main():
     tau = pa.TauArgus(r'C:\Users\LVWN\Desktop\TauArgus4.2.0b5\TauArgus')
     input_df = pd.read_csv('data/microdata.csv')
-    input_data = pa.MicroData(input_df, name='example')
+    input_data = pa.MicroData(input_df)
     tables = [pa.Table(['sbi', 'regio'],
                        response=pa.FREQUENCY_RESPONSE,
                        cost=pa.UNITY_COST,
-                       name='T5',
                        safety_rule=pa.frequency_rule(3, 20),
                        suppress_method=pa.OPTIMAL)]
     job = pa.Job(input_data, tables, directory='tau', name='response_example')

--- a/examples/tabledata_basic.py
+++ b/examples/tabledata_basic.py
@@ -8,12 +8,11 @@ def main():
     tau = pa.TauArgus(r'C:\Users\LVWN\Desktop\TauArgus4.2.0b5\TauArgus')
     input_df = pd.read_csv("data/tabledata.csv")
     table = pa.TableData(input_df, ["activity", "size"], "val",
-                         name='T2',
                          safety_rule={pa.frequency_rule(3, 10), pa.dominance_rule(1, 85)},
                          frequency="n_obs",
                          top_contributors=["max"],
                          suppress_method=pa.GHMITER)
-    job = pa.Job(table, directory='tau', name='tabledata_example')
+    job = pa.Job(table, directory='tau', name='tabledata-example')
     result = tau.run(job)
     table_result = table.load_result()
 

--- a/examples/tabledata_status.py
+++ b/examples/tabledata_status.py
@@ -9,11 +9,10 @@ def main():
     input_df = pd.read_csv("data/tabledata_status.csv")
     table = pa.TableData(input_df, ["activity", "size"], "val",
                          status_indicator="status",
-                         name='T_status',
                          frequency="n_obs",
                          top_contributors=["max"],
                          suppress_method=pa.GHMITER)
-    job = pa.Job(table, directory='tau', name='tabledata_status')
+    job = pa.Job(table, directory='tau', name='tabledata-status')
     result = tau.run(job)
     table_result = table.load_result()
 

--- a/piargus/__init__.py
+++ b/piargus/__init__.py
@@ -3,6 +3,7 @@ from piargus.argusreport import TauArgusException
 from piargus.batchwriter import BatchWriter
 from piargus.codelist import CodeList
 from piargus.constants import *
+from piargus.graphrecode import GraphRecode
 from piargus.hierarchy import Hierarchy
 from piargus.inputdata import InputData
 from piargus.job import Job

--- a/piargus/__init__.py
+++ b/piargus/__init__.py
@@ -16,4 +16,4 @@ from piargus.tabledata import TableData
 from piargus.tauargus import TauArgus
 
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/piargus/__init__.py
+++ b/piargus/__init__.py
@@ -13,6 +13,7 @@ from piargus.safetyrule import dominance_rule, percent_rule, frequency_rule, req
     missing_rule, weight_rule, manual_rule, p_rule, nk_rule
 from piargus.table import Table
 from piargus.tabledata import TableData
+from piargus.tableset import TableSet
 from piargus.tauargus import TauArgus
 
 

--- a/piargus/batchwriter.py
+++ b/piargus/batchwriter.py
@@ -66,6 +66,13 @@ class BatchWriter:
         arg = f"{filename}, {table}, {separator}, {ignore_error}, {expand_trivial}"
         return self.write_command("APRIORI", arg)
 
+    def recode(self, table, variable, file_or_treelevel):
+        table = int(table)
+        variable = format_argument(variable)
+        file_or_treelevel = format_argument(file_or_treelevel)
+        arg = f"{table}, {variable}, {file_or_treelevel}"
+        return self.write_command("RECODE", arg)
+
     def safety_rule(self, rules):
         if isinstance(rules, str):
             rules = (rules,)

--- a/piargus/batchwriter.py
+++ b/piargus/batchwriter.py
@@ -70,11 +70,7 @@ class BatchWriter:
         return self.write_command("RECODE", arg)
 
     def safety_rule(self, rule="", /, *, individual="", holding=""):
-        if not rule:
-            rule = make_safety_rule(individual, holding)
-        elif not isinstance(rule, str):
-            rule = "|".join(rule)
-
+        rule = make_safety_rule(rule, individual=individual, holding=holding)
         return self.write_command('SAFETYRULE', rule)
 
     def suppress(self, method, table, *method_args):

--- a/piargus/batchwriter.py
+++ b/piargus/batchwriter.py
@@ -38,7 +38,8 @@ class BatchWriter:
     def open_metadata(self, metadata):
         return self.write_command("OPENMETADATA", format_argument(metadata))
 
-    def specify_table(self, explanatory, response=FREQUENCY_RESPONSE, shadow=None, cost=None, labda=None):
+    def specify_table(self, explanatory, response=FREQUENCY_RESPONSE, shadow=None, cost=None,
+                      labda=None):
         explanatory_str = "".join([format_argument(v) for v in explanatory])
         response_str = format_argument(response)
         shadow_str = format_argument(shadow)

--- a/piargus/graphrecode.py
+++ b/piargus/graphrecode.py
@@ -1,0 +1,42 @@
+import io
+import os
+from pathlib import Path
+
+
+class GraphRecode:
+    HEADER = "<TREERECODE>"
+
+    def __init__(self, codes):
+        self.codes = list(str(code) for code in codes)
+        self.filepath = None
+
+    @classmethod
+    def from_grc(cls, file):
+        if isinstance(file, (str, Path)):
+            with open(file) as reader:
+                graph_recode = cls.from_grc(reader)
+                graph_recode.filepath = Path(file)
+                return graph_recode
+
+        codes = list()
+        for line in file:
+            if line.strip().upper() == cls.HEADER:
+                continue
+            else:
+                codes.append(line)
+
+        return cls(codes)
+
+    def to_grc(self, file=None):
+        if file is None:
+            file = io.StringIO(newline=os.linesep)
+            self.to_grc(file)
+            return file.getvalue()
+        elif not hasattr(file, 'write'):
+            self.filepath = Path(file)
+            with open(file, 'w', newline='\n') as writer:
+                return self.to_grc(writer)
+
+        file.write(f"{self.HEADER}\n")
+        for code in self.codes:
+            file.write(code)

--- a/piargus/graphrecode.py
+++ b/piargus/graphrecode.py
@@ -27,16 +27,18 @@ class GraphRecode:
 
         return cls(codes)
 
-    def to_grc(self, file=None):
+    def to_grc(self, file=None, length=0):
         if file is None:
             file = io.StringIO(newline=os.linesep)
-            self.to_grc(file)
+            self.to_grc(file, length)
             return file.getvalue()
+
         elif not hasattr(file, 'write'):
             self.filepath = Path(file)
             with open(file, 'w', newline='\n') as writer:
-                return self.to_grc(writer)
+                self.to_grc(writer, length)
 
-        file.write(f"{self.HEADER}\n")
-        for code in self.codes:
-            file.write(code)
+        else:
+            file.write(f"{self.HEADER}\n")
+            for code in self.codes:
+                file.write(code.rjust(length) + "\n")

--- a/piargus/inputdata.py
+++ b/piargus/inputdata.py
@@ -1,4 +1,5 @@
 import abc
+import warnings
 from typing import Dict
 
 from pandas.core.dtypes.common import is_string_dtype, is_categorical_dtype, is_bool_dtype
@@ -24,7 +25,7 @@ class InputData(metaclass=abc.ABCMeta):
         Abstract class for input data. Either initialize MicroData or TableData.
 
         :param dataset: The dataset to make tables for.
-        :param name: The name to use when write the data to a file.
+        :param name: (unused)
         :param hierarchies: The hierarchies to use for categorial data in the dataset.
         :param codelists: Codelists (dicts) for categorical data in the dataset.
         :param column_lengths: For each column the length.
@@ -32,8 +33,8 @@ class InputData(metaclass=abc.ABCMeta):
         The lengths can also be derived by calling resolve_column_lengths.
         """
 
-        if name is None:
-            name = f'data_{id(self)}'
+        if name is not None:
+            warnings.warn("Name on input_data is no longer used.")
 
         if hierarchies is None:
             hierarchies = dict()
@@ -51,7 +52,6 @@ class InputData(metaclass=abc.ABCMeta):
             raise TypeError("Total codes must be a dict.")
 
         self.dataset = dataset
-        self.name = name
         self.hierarchies = hierarchies
         self.codelists = codelists
         self.column_lengths = column_lengths

--- a/piargus/job.py
+++ b/piargus/job.py
@@ -198,18 +198,16 @@ class Job:
             writer = BatchWriter(batch)
 
             if isinstance(self.input_data, Table):
-                writer.open_tabledata(str(self.input_data.filepath))
+                writer.open_tabledata(self.input_data)
             else:
-                writer.open_microdata(str(self.input_data.filepath))
+                writer.open_microdata(self.input_data)
 
-            writer.open_metadata(str(self.metadata.filepath))
+            writer.open_metadata(self.metadata)
 
             for table in self.tables:
                 writer.specify_table(table.explanatory, table.response, table.shadow, table.cost,
                                      table.labda)
-
-                safety_rules = table.safety_rule,
-                writer.safety_rule(safety_rules)
+                writer.safety_rule(table.safety_rule)
 
             if isinstance(self.input_data, Table):
                 writer.read_table()
@@ -219,7 +217,7 @@ class Job:
             for t_index, table in enumerate(self.tables, 1):
                 if table.apriori:
                     writer.apriori(
-                        table.apriori.filepath,
+                        table.apriori,
                         t_index,
                         separator=table.apriori.separator,
                         ignore_error=table.apriori.ignore_error,
@@ -227,17 +225,14 @@ class Job:
                     )
 
                 for variable, recode in table.recodes.items():
-                    if isinstance(recode, GraphRecode):
-                        writer.recode(t_index, variable, recode.filepath)
-                    else:
-                        writer.recode(t_index, variable, recode)
+                    writer.recode(t_index, variable, recode)
 
                 if table.suppress_method:
                     writer.suppress(table.suppress_method, t_index, *table.suppress_method_args)
 
             # Linked suppression
             if self.tables.suppress_method:
-                writer.suppress(self.tables.suppress_method, 0)
+                writer.suppress(self.tables.suppress_method, 0, *self.tables.suppress_method_args)
 
             for t_index, table in enumerate(self.tables, 1):
                 writer.write_table(t_index, 2, {"AS": True}, str(table.filepath_out))

--- a/piargus/safetyrule.py
+++ b/piargus/safetyrule.py
@@ -138,6 +138,6 @@ def _split_rule(rule: Union[str, Collection[str]]) -> Sequence[str]:
     ['P(1)', 'NK(3, 7)', 'FREQ(1)', 'NK(3, 7)', 'ZERO(5)', 'P(1,2)', 'MIS(1)']
     """
     if isinstance(rule, str):
-        return [part.strip() for part in rule.split("|")]
+        return [part.strip() for part in rule.split("|") if part]
     else:
         return [part for subrule in rule for part in _split_rule(subrule)]

--- a/piargus/safetyrule.py
+++ b/piargus/safetyrule.py
@@ -1,4 +1,4 @@
-from typing import Union, Collection, Sequence
+from typing import Union, Collection, Sequence, Mapping
 
 
 def safety_rule(code, maximum=None, dummy=None):
@@ -102,13 +102,27 @@ nk_rule = dominance_rule
 p_rule = percent_rule
 
 
-def make_safety_rule(individual: Union[str, Collection[str]],
-                     holding: Union[str, Collection[str]]) -> str:
+def make_safety_rule(
+    rule: Union[str, Collection[str]] = "", /, *,
+    individual: Union[str, Collection[str]] = "",
+    holding: Union[str, Collection[str]] = "",
+) -> str:
     """
     Construct a safety rule from individual and holding parts.
 
     Dummy elements are inserted when necessary.
     """
+    if rule:
+        if individual or holding:
+            raise ValueError("Function should either be called with 1 positional "
+                             "or 2 keyword arguments.")
+        elif isinstance(rule, str):
+            return rule
+        elif isinstance(rule, Mapping):
+            return make_safety_rule(**rule)
+        else:
+            return "|".join(_split_rule(rule))
+
     if isinstance(individual, str):
         individual = _split_rule(individual)
     if isinstance(holding, str):

--- a/piargus/safetyrule.py
+++ b/piargus/safetyrule.py
@@ -1,4 +1,4 @@
-from typing import Union, Collection, Sequence, Mapping
+from typing import Union, Collection, Sequence, Mapping, TypedDict
 
 
 def safety_rule(code, maximum=None, dummy=None):
@@ -102,8 +102,13 @@ nk_rule = dominance_rule
 p_rule = percent_rule
 
 
+class SafetyRuleDict(TypedDict, total=False):
+    individual: Union[str, Collection[str]]
+    holding: Union[str, Collection[str]]
+
+
 def make_safety_rule(
-    rule: Union[str, Collection[str]] = "", /, *,
+    rule: Union[str, Collection[str], SafetyRuleDict] = "", /, *,
     individual: Union[str, Collection[str]] = "",
     holding: Union[str, Collection[str]] = "",
 ) -> str:
@@ -114,8 +119,8 @@ def make_safety_rule(
     """
     if rule:
         if individual or holding:
-            raise ValueError("Function should either be called with 1 positional "
-                             "or 2 keyword arguments.")
+            raise TypeError("Function should either be called with 1 positional "
+                            "or 2 keyword arguments.")
         elif isinstance(rule, str):
             return rule
         elif isinstance(rule, Mapping):

--- a/piargus/table.py
+++ b/piargus/table.py
@@ -6,7 +6,7 @@ import pandas as pd
 from .apriori import Apriori
 from .constants import FREQUENCY_RESPONSE, OPTIMAL
 from .graphrecode import GraphRecode
-from .safetyrule import make_safety_rule
+from .safetyrule import make_safety_rule, SafetyRuleDict
 from .tableresult import TableResult
 
 
@@ -19,7 +19,7 @@ class Table:
         cost: Optional[Union[int, str]] = None,
         labda: int = None,
         name: str = None,  # Deprecated
-        safety_rule: Union[str, Collection[str], Mapping[str, Collection[str]]] = (),
+        safety_rule: Union[str, Collection[str], SafetyRuleDict] = (),
         apriori: Union[Apriori, Iterable[Sequence[Any]]] = (),
         recodes: Mapping[str, Union[int, GraphRecode]] = None,
         suppress_method: Optional[str] = OPTIMAL,
@@ -97,10 +97,7 @@ class Table:
         return self._safety_rule
 
     @safety_rule.setter
-    def safety_rule(
-        self,
-        rule: Union[str, Collection[str],  Mapping[str, Union[str, Collection[str]]]] = ""
-    ):
+    def safety_rule(self, rule: Union[str, Collection[str], SafetyRuleDict] = ""):
         self._safety_rule = make_safety_rule(rule)
 
     @property

--- a/piargus/table.py
+++ b/piargus/table.py
@@ -70,11 +70,12 @@ class Table:
         :param suppress_method_args: Parameters to pass to suppress_method.
         """
 
+        if name is not None:
+            warnings.warn("name is deprecated, pass a dict to Job instead")
+
         if not isinstance(apriori, Apriori):
             apriori = Apriori(apriori)
 
-        if name is not None:
-            warnings.warn("name is deprecated, pass a dict to Job instead")
 
         if safety_rules is not None:
             warnings.warn("safety_rules is deprecated, use safety_rule instead")

--- a/piargus/table.py
+++ b/piargus/table.py
@@ -17,7 +17,7 @@ class Table:
         shadow: Optional[str] = None,
         cost: Optional[Union[int, str]] = None,
         labda: int = None,
-        name: str = None,
+        name: str = None,  # Deprecated
         safety_rule: Union[str, Collection[str], Mapping[str, Collection[str]]] = (),
         safety_rules=None,  # Deprecated
         safety_rules_holding=None,  # Deprecated
@@ -55,7 +55,7 @@ class Table:
         - "FREQ(minfreq, safety_range)": Frequency rule
         - "REQ(percentage_1, percentage_2, safety_margin)": Request rule
         See the Tau-Argus manual for details on those rules.
-        :param name: Name to use for generated files
+        :param name: (unused)
         :param apriori: Apriori file to change parameters
         :param suppress_method: Method to use for secondary suppression.
         Options are:
@@ -70,11 +70,11 @@ class Table:
         :param suppress_method_args: Parameters to pass to suppress_method.
         """
 
-        if name is None:
-            name = f'table_{id(self)}'
-
         if not isinstance(apriori, Apriori):
             apriori = Apriori(apriori)
+
+        if name is not None:
+            warnings.warn("name is deprecated, pass a dict to Job instead")
 
         if safety_rules is not None:
             warnings.warn("safety_rules is deprecated, use safety_rule instead")
@@ -92,7 +92,6 @@ class Table:
         self.shadow = shadow
         self.cost = cost
         self.labda = labda
-        self.name = name
         self.filepath_out = None
         self.safety_rule = safety_rule
         self.apriori = apriori

--- a/piargus/table.py
+++ b/piargus/table.py
@@ -20,8 +20,6 @@ class Table:
         labda: int = None,
         name: str = None,  # Deprecated
         safety_rule: Union[str, Collection[str], Mapping[str, Collection[str]]] = (),
-        safety_rules=None,  # Deprecated
-        safety_rules_holding=None,  # Deprecated
         apriori: Union[Apriori, Iterable[Sequence[Any]]] = (),
         recodes: Mapping[str, Union[int, GraphRecode]] = None,
         suppress_method: Optional[str] = OPTIMAL,
@@ -75,26 +73,12 @@ class Table:
         if name is not None:
             warnings.warn("name is deprecated, pass a dict to Job instead")
 
-        if not isinstance(apriori, Apriori):
-            apriori = Apriori(apriori)
-
         if recodes:
             recodes = {col: (recode if isinstance(recode, (int, GraphRecode))
                              else GraphRecode(recode))
                        for col, recode in recodes.items()}
         else:
             recodes = dict()
-
-        if safety_rules is not None:
-            warnings.warn("safety_rules is deprecated, use safety_rule instead")
-            safety_rule = safety_rules
-
-        if safety_rules_holding is not None:
-            warnings.warn("safety_rules_holding is deprecated"
-                          'use safety_rule={'
-                          '"individual": individual_rules, '
-                          '"holding": holding_rules} instead')
-            safety_rule = make_safety_rule(safety_rule, safety_rules_holding)
 
         self.explanatory = explanatory
         self.response = response
@@ -113,14 +97,21 @@ class Table:
         return self._safety_rule
 
     @safety_rule.setter
-    def safety_rule(self,
-                    value: Union[str, Collection[str], Mapping[str, Union[str, Collection[str]]]]):
-        if isinstance(value, str):
-            self._safety_rule = value
-        elif isinstance(value, dict):
-            self._safety_rule = make_safety_rule(**value)
-        else:
-            self._safety_rule = "|".join(value)
+    def safety_rule(
+        self,
+        rule: Union[str, Collection[str],  Mapping[str, Union[str, Collection[str]]]] = ""
+    ):
+        self._safety_rule = make_safety_rule(rule)
+
+    @property
+    def apriori(self):
+        return self._apriori
+
+    @apriori.setter
+    def apriori(self, value):
+        if not isinstance(value, Apriori):
+            value = Apriori(value)
+        self._apriori = value
 
     def load_result(self) -> TableResult:
         if self.response == FREQUENCY_RESPONSE:

--- a/piargus/tableset.py
+++ b/piargus/tableset.py
@@ -1,14 +1,36 @@
-from typing import Mapping, Hashable, Union, Iterable
+import warnings
+from typing import Mapping, Hashable, Union, Iterable, Optional, Sequence
 
 from .table import Table
 
 
 class TableSet:
     """A collection of tables that can be used as frozen dictionary or list."""
-    __slots__ = "_tables"
+    __slots__ = "_tables", "suppress_method", "suppress_method_args"
 
-    def __init__(self, tables: Union[Mapping[Hashable, Table], Iterable[Table]]):
-        if isinstance(tables, Mapping):
+    def __init__(
+        self,
+        tables: Union[Mapping[Hashable, Table], Iterable[Table]],
+        suppress_method: Optional[str] = None,  # Experimental
+        suppress_method_args: Sequence = ()  # Experimental
+    ):
+        """
+        Create a tableset
+
+        Parameters:
+        :param tables: Either a mapping or an iterable containing the Tables.
+        :param suppress_method: Method to use for linked suppression.
+        Options are:
+        - `GHMITER` ("GH"): Hypercube
+        - `MODULAR` ("MOD"): Modular
+        Warning: The Tau-Argus manual doesn't document this. Therefore, usage is not recommended.
+        :param suppress_method_args: Parameters to pass to suppress_method.
+        """
+        if isinstance(tables, TableSet):
+            suppress_method = tables.suppress_method
+            suppress_method_args = tables.suppress_method_args
+
+        if isinstance(tables, (TableSet, Mapping)):
             tables = {key: table if isinstance(table, Table) else Table(**table)
                       for key, table in tables.items()}
         elif isinstance(tables, Iterable):
@@ -17,7 +39,13 @@ class TableSet:
         else:
             raise TypeError("tables should be Dict or Iterable")
 
+        if suppress_method:
+            warnings.warn("Protection of linked tables by batchfile isn't officially documented. "
+                          "Therefore, correct results are NOT guaranteed.")
+
         self._tables = tables
+        self.suppress_method = suppress_method
+        self.suppress_method_args = suppress_method_args
 
     def __repr__(self):
         type_name = self.__class__.__qualname__
@@ -31,6 +59,9 @@ class TableSet:
 
     def __iter__(self):
         return iter(self._tables.values())
+
+    def __contains__(self, item):
+        return item in self._tables
 
     def keys(self):
         return self._tables.keys()

--- a/piargus/tableset.py
+++ b/piargus/tableset.py
@@ -1,0 +1,42 @@
+from typing import Mapping, Hashable, Union, Iterable
+
+from .table import Table
+
+
+class TableSet:
+    """A collection of tables that can be used as frozen dictionary or list."""
+    __slots__ = "_tables"
+
+    def __init__(self, tables: Union[Mapping[Hashable, Table], Iterable[Table]]):
+        if isinstance(tables, Mapping):
+            tables = {key: table if isinstance(table, Table) else Table(**table)
+                      for key, table in tables.items()}
+        elif isinstance(tables, Iterable):
+            tables = {index: table if isinstance(table, Table) else Table(**table)
+                      for index, table in enumerate(tables)}
+        else:
+            raise TypeError("tables should be Dict or Iterable")
+
+        self._tables = tables
+
+    def __repr__(self):
+        type_name = self.__class__.__qualname__
+        return f"{type_name}({self._tables})"
+
+    def __len__(self):
+        return len(self._tables)
+
+    def __getitem__(self, key):
+        return self._tables[key]
+
+    def __iter__(self):
+        return iter(self._tables.values())
+
+    def keys(self):
+        return self._tables.keys()
+
+    def values(self):
+        return self._tables.values()
+
+    def items(self):
+        return self._tables.items()

--- a/piargus/tauargus.py
+++ b/piargus/tauargus.py
@@ -18,12 +18,14 @@ class TauArgus:
         """Run either a batch file or a job."""
         if batch_or_job is None:
             result = self._run_interactively()
+        elif isinstance(batch_or_job, str):
+            result = self._run_batch(batch_or_job, *args, **kwargs)
         elif hasattr(batch_or_job, 'batch_filepath'):
             result = self._run_job(batch_or_job, *args, **kwargs)
         elif hasattr(batch_or_job, '__iter__'):
             result = self._run_parallel(batch_or_job, *args, **kwargs)
         else:
-            result = self._run_batch(batch_or_job, *args, **kwargs)
+            raise TypeError
 
         if check:
             if hasattr(result, '__iter__'):

--- a/piargus/utils.py
+++ b/piargus/utils.py
@@ -1,14 +1,34 @@
+import re
 from pathlib import Path
 
+import unicodedata
 
-def format_argument(text):
-    if text is None:
+
+def format_argument(argument) -> str:
+    if argument is None:
         return ""
-    elif isinstance(text, Path):
-        return f'"{text!s}"'
-    elif isinstance(text, str):
-        return f'"{text!s}"'
-    elif isinstance(text, bool):
-        return str(int(text))
+    elif isinstance(argument, Path):
+        return f'"{argument!s}"'
+    elif isinstance(argument, str):
+        return f'"{argument!s}"'
+    elif isinstance(argument, bool):
+        return str(int(argument))
     else:
-        return str(text)
+        return str(argument)
+
+
+def slugify(value, allow_unicode=False) -> str:
+    """
+    Taken from https://github.com/django/django/blob/master/django/utils/text.py
+    Convert to ASCII if 'allow_unicode' is False. Convert spaces or repeated
+    dashes to single dashes. Remove characters that aren't alphanumerics,
+    underscores, or hyphens. Convert to lowercase. Also strip leading and
+    trailing whitespace, dashes, and underscores.
+    """
+    value = str(value)
+    if allow_unicode:
+        value = unicodedata.normalize('NFKC', value)
+    else:
+        value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore').decode('ascii')
+    value = re.sub(r'[^\w\s-]', '', value.lower())
+    return re.sub(r'[-\s]+', '-', value).strip('-_')

--- a/piargus/utils.py
+++ b/piargus/utils.py
@@ -7,12 +7,17 @@ import unicodedata
 def format_argument(argument) -> str:
     if argument is None:
         return ""
+    elif isinstance(argument, bool):
+        return str(int(argument))
     elif isinstance(argument, Path):
         return f'"{argument!s}"'
     elif isinstance(argument, str):
         return f'"{argument!s}"'
-    elif isinstance(argument, bool):
-        return str(int(argument))
+    elif hasattr(argument, "filepath"):
+        if argument.filepath is not None:
+            return f'"{argument.filepath!s}"'
+        else:
+            raise ValueError(f"Make sure to save {argument!r} first.")
     else:
         return str(argument)
 

--- a/tests/test_batchwriter.py
+++ b/tests/test_batchwriter.py
@@ -1,7 +1,7 @@
 import io
 from unittest import TestCase
 
-from piargus import BatchWriter
+from piargus import BatchWriter, MetaData
 
 
 class TestBatchWriter(TestCase):
@@ -15,6 +15,7 @@ class TestBatchWriter(TestCase):
         writer.open_metadata('metadata.rda')
         writer.specify_table(["sbi", "gk"], "income")
         writer.safety_rule({"NK(3, 70)"})
+        writer.safety_rule(holding={"P(5)"})
         writer.apriori("apriori.hst", 55, ignore_error=True, expand_trivial=False)
         writer.read_microdata()
         writer.read_table()
@@ -31,6 +32,7 @@ class TestBatchWriter(TestCase):
             '<OPENMETADATA>\t"metadata.rda"\n',
             '<SPECIFYTABLE>\t"sbi""gk"|"income"||\n',
             '<SAFETYRULE>\tNK(3, 70)\n',
+            '<SAFETYRULE>\tP(0, 0)|P(0, 0)|P(5)\n',
             '<APRIORI>\t"apriori.hst", 55, ",", 1, 0\n',
             '<READMICRODATA>\n',
             '<READTABLE>\n',

--- a/tests/test_batchwriter.py
+++ b/tests/test_batchwriter.py
@@ -15,7 +15,6 @@ class TestBatchWriter(TestCase):
         writer.open_metadata('metadata.rda')
         writer.specify_table(["sbi", "gk"], "income")
         writer.safety_rule({"NK(3, 70)"})
-        writer.safety_rule(holding={"P(5)"})
         writer.apriori("apriori.hst", 55, ignore_error=True, expand_trivial=False)
         writer.read_microdata()
         writer.read_table()
@@ -32,7 +31,6 @@ class TestBatchWriter(TestCase):
             '<OPENMETADATA>\t"metadata.rda"\n',
             '<SPECIFYTABLE>\t"sbi""gk"|"income"||\n',
             '<SAFETYRULE>\tNK(3, 70)\n',
-            '<SAFETYRULE>\tP(0, 0)|P(0, 0)|P(5)\n',
             '<APRIORI>\t"apriori.hst", 55, ",", 1, 0\n',
             '<READMICRODATA>\n',
             '<READTABLE>\n',

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -24,8 +24,8 @@ class TestSafetyRule(unittest.TestCase):
 
     def test_make_safety_rule(self):
         result = make_safety_rule(
-            [rule.dominance_rule(3, 75), rule.frequency_rule(5, 20)],
-            [rule.p_rule(5), rule.frequency_rule(6, 15), rule.request_rule(2, 2, 9)],
+            individual=[rule.dominance_rule(3, 75), rule.frequency_rule(5, 20)],
+            holding=[rule.p_rule(5), rule.frequency_rule(6, 15), rule.request_rule(2, 2, 9)],
         )
         expected = "|".join([
             'NK(3, 75)',
@@ -41,7 +41,11 @@ class TestSafetyRule(unittest.TestCase):
 
     def test_make_safety_rule_maximum(self):
         with self.assertRaises(ValueError):
-            make_safety_rule([rule.p_rule(2), rule.p_rule(3), rule.p_rule(4)], [])
+            make_safety_rule(individual=[rule.p_rule(2), rule.p_rule(3), rule.p_rule(4)])
+
+    def test_make_safety_rule_holding_only(self):
+        result = make_safety_rule(holding="P(5)")
+        self.assertEqual("P(0, 0)|P(0, 0)|P(5)", result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Remove `name` parameter on most object, except Job
- Job construct now accepts tables as both iterable or dict.
  Tables will now be stored in a TableSet object.
- Experimental linked protection is possible by using a TableSet.
  Although it seems to work fine, this feature is not documented in the manual.
  Therefore, usage cannot be recommended.